### PR TITLE
tidy tqdm usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2334,7 +2334,7 @@ Progress Bar
 # $ pip3 install tqdm
 from tqdm import tqdm
 from time import sleep
-for el in tqdm([1, 2, 3]):
+for el in tqdm(<iter> [, desc=<str>][, total=<int>][, leave=<bool>]):
     sleep(0.2)
 ```
 


### PR DESCRIPTION
- adds a few common options
- also uses `<iter>` instead of `[1, 2, 3]`. Maybe use `<collection>` instead? Or just leave as `[1, 2, 3]`?